### PR TITLE
HTTP service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,20 @@ When using AWS credentials or IAM Roles, the following policy needs to be attach
 Usage of ./prometheus-msk-discovery:
   -filter string
     	a regex pattern to filter cluster names from the results
+  -http-sd
+    	expose http_sd interface rather than writing a file
   -job-prefix string
     	string with which to prefix each job label (default "msk")
+  -listen-address string
+    	Address to listen on for http service discovery (default ":8080")
   -output string
     	path of the file to write MSK discovery information to (default "msk_file_sd.yml")
+  -region string
+    	the aws region in which to scan for MSK clusters
   -scrape-interval duration
     	interval at which to scrape the AWS API for MSK cluster information (default 5m0s)
+  -tag value
+    	A key=value for filtering by tags. Flag can be specified multiple times, resulting OR expression.
 ```
 
 ### Example output:
@@ -60,6 +68,23 @@ $ ./prometheus-msk-discovery -scrape-interval 10s -filter 'primary'
 ```
 
 An example output file can be found [here](examples/msk_file_sd.yml)
+
+### http_sd
+
+```
+$ ./prometheus-msk-discovery -http-sd -listen-address :8989 -filter 'primary
+``
+
+```
+$ curl localhost:8989
+[{"targets":["b-1.primary-kafka.tffs8g.c2.kafka.eu-west-2.amazonaws.com:11001","b-1.primary-kafka.tffs8g.c2.kafka.eu-west-2.amazonaws.com:11002","b-2.primary-kafka.tffs8g.c2.kafka.eu-west-2.amazonaws.com:11001","b-2.primary-kafka.tffs8g.c2.kafka.eu-west-2.amazonaws.com:11002"],"labels":{"job":"msk-primary-kafka","cluster_name":"primary-kafka","cluster_arn":"arn:aws:kafka:eu-west-2:111111111111:cluster/primary-kafka/522d90ab-d400-4ea0-b8fd-bbf3576425d4-2"}}]
+```
+
+```yaml
+http_sd_configs:
+  - url: http://localhost:8989
+    refresh_interval: 30s
+```
 
 ## Region Precedence
 When no region is specified with the `-region` flag the process first attempts to load the default SDK configuration checking for an `AWS_REGION` environment variable or reading any region specified in the standard [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html). If no region is found it will attempt to retrieve it from the EC2 Instance Metadata Service.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Service discovery for [AWS MSK](https://aws.amazon.com/msk/), compatible with [P
 
 ## How it works
 
-This service gets a list of MSK clusters in an AWS account and exports each broker to a Prometheus-compatible static config to be used with the [`file_sd_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config) mechanism.
+This service gets a list of MSK clusters in an AWS account and exports each broker to a Prometheus-compatible static config to be used with the [`file_sd_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config) or [`http_sd_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config) mechanism.
 
 ## Pre-requisites
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ An example output file can be found [here](examples/msk_file_sd.yml)
 ### http_sd
 
 ```
-$ ./prometheus-msk-discovery -http-sd -listen-address :8989 -filter 'primary
-``
+$ ./prometheus-msk-discovery -http-sd -listen-address :8989 -filter 'primary'
+```
 
 ```
 $ curl localhost:8989

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Usage of ./prometheus-msk-discovery:
   -region string
     	the aws region in which to scan for MSK clusters
   -scrape-interval duration
-    	interval at which to scrape the AWS API for MSK cluster information (default 5m0s)
+    	interval at which to scrape the AWS API for MSK cluster information when in file_sd mode (default 5m0s)
   -tag value
     	A key=value for filtering by tags. Flag can be specified multiple times, resulting OR expression.
 ```

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ type tags map[string]string
 
 var (
 	outFile       = flag.String("output", "msk_file_sd.yml", "path of the file to write MSK discovery information to")
-	interval      = flag.Duration("scrape-interval", 5*time.Minute, "interval at which to scrape the AWS API for MSK cluster information")
+	interval      = flag.Duration("scrape-interval", 5*time.Minute, "interval at which to scrape the AWS API for MSK cluster information when in file_sd mode")
 	jobPrefix     = flag.String("job-prefix", "msk", "string with which to prefix each job label")
 	clusterFilter = flag.String("filter", "", "a regex pattern to filter cluster names from the results")
 	awsRegion     = flag.String("region", "", "the aws region in which to scan for MSK clusters")


### PR DESCRIPTION
In our environment we make use of prometheus operator to configure prometheus for us.

Whilst it is possible to use file_sd in our environment it's a bit more of a pain to configure, as would need to add a sidecar to our prometheus, and add a shared volume so the file can be read.

With http_sd we can just run a Deployment of prometheus-msk-discovery and drop a [`ScrapeConfig`](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1alpha1.ScrapeConfig) resource into our manifests.

The shape of the API is exactly the same, only difference is it needs to be json, rather than yaml.

I added a flag `-http-sd` to enable this second mode - without it everything should behave exactly the same as it did before, so as to not cause any issues for existing users.